### PR TITLE
Fixed json serialization for 'bytes' field - value base64 encoded with extra newline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS = -Wl,-rpath -Wl,.
 all: libjson2pb.so test_json
 
 clean:
-	-rm -f *.o *.so *.a libjson2pb.so.* test
+	-rm -f *.o *.so *.a libjson2pb.so.* test test_pb2.py *.pyc
 
 test_json: test_json.o test.pb.o libjson2pb.so -lprotobuf
 test_json.o: test.pb.h
@@ -16,3 +16,9 @@ libjson2pb.so: json2pb.o
 
 test.pb.h test.pb.cc: test.proto
 	protoc --cpp_out=$(shell pwd) test.proto
+
+test_pb2.py: test.proto
+	protoc --python_out=$(shell pwd) test.proto
+
+json2pb_python_unittest: test_pb2.py
+	nosetests -v json2pb_unittest.py

--- a/json2pb.py
+++ b/json2pb.py
@@ -18,6 +18,7 @@ Import this file to add functions
 Also they may be used as json_encode and json_decode
 """
 
+import base64
 from google.protobuf.message import Message
 
 
@@ -70,7 +71,7 @@ def pb2jd(o):
         if d.type == d.TYPE_MESSAGE:
             return pb2jd(obj)
         elif d.type == d.TYPE_BYTES:
-            return obj.encode('base64')
+            return base64.b64encode(obj)
         else:
             return obj
 
@@ -97,7 +98,7 @@ def jd2pb(descriptor, jdict):
         if d.type == d.TYPE_MESSAGE:
             return jd2pb(d.message_type, obj)
         elif d.type == d.TYPE_BYTES:
-            return obj.decode('base64')
+            return base64.b64decode(obj)
         else:
             return obj
 

--- a/json2pb_unittest.py
+++ b/json2pb_unittest.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+#
+# Note that json2pb.py does not support protobuf extension yet.
+#
+import json2pb
+import simplejson as json
+import test_pb2
+import unittest
+from google.protobuf import text_format
+
+json_string = """
+{
+  "_str": "b",
+  "_bin": "0a0a0a0a",
+  "_bool": true,
+  "_float": 1,
+  "sub": {
+    "field": "subfield",
+    "echo": [
+     {"text": "first"},
+     {"text": "second"}
+    ]
+  },
+  "_int": [10, 20, 30, 40],
+  "_enum":  [10, 20],
+  "str_list":["v0", "v1"],
+  "test.e_bool":false
+}
+"""
+
+proto_string = """
+_str: "b"
+_float: 1
+_int: 10
+_int: 20
+_int: 30
+_int: 40
+_bin: "\321\255\032\321\255\032"
+_bool: true
+sub {
+  field: "subfield"
+  echo {
+    text: "first"
+  }
+  echo {
+    text: "second"
+  }
+}
+_enum: VALUE1
+_enum: VALUE2
+str_list: "v0"
+str_list: "v1"
+"""
+
+class TestJson2Pb(unittest.TestCase):
+    def test_conversion(self):
+        json_msg = test_pb2.ComplexMessage()
+        json_msg.ParseFromJSON(json_string)
+
+        proto_msg = test_pb2.ComplexMessage()
+        text_format.Parse(proto_string, proto_msg)
+
+        self.assertEqual(json_msg, proto_msg)
+
+    def test_byte_base64(self):
+        json_msg = test_pb2.ComplexMessage()
+        json_msg.ParseFromJSON(json_string)
+        json_dict = json.loads(json_string)
+
+        json_msg_string = json_msg.SerializeToJSON()
+        json_msg_dict = json.loads(json_msg_string);
+
+        self.assertEqual(json_msg_dict['_bin'], json_dict['_bin'])


### PR DESCRIPTION
Notice that for json2pb.py, using test.proto, the value for '_bin' field is incorrectly serialized into '0a0a0a0a\n' after doing json->pb->json. 

As shown in http://bugs.python.org/issue17714, python str.encode() with 'base64' as argument adds a trailing new line character to the returned string. This causes the bug in json2pb.py when handling bytes field.
- Replaced str.encode('base64') with base64.b64encode(str).
- Added a unit test for json2pb.py. Test case 'test_bytes_base64' shall fail without the fix.
